### PR TITLE
Disable user interaction until presentation animation is complete

### DIFF
--- a/JFDepthView/JFDepthView.m
+++ b/JFDepthView/JFDepthView.m
@@ -242,6 +242,8 @@
     NSParameterAssert(topView);
     NSParameterAssert(bottomView);
     
+    self.view.userInteractionEnabled = NO;
+    
     /**
      * Save the original view frame so it can be reset after being presented.
      * This eliminates an issue of continually reducing the size of a persistant 
@@ -361,6 +363,7 @@
     } completion:^(BOOL finished){
         NSLog(@"JFDepthView: Present Animation Complete");
         
+        self.view.userInteractionEnabled = YES;
         self.isPresenting = YES;
         [self removeAllAnimations];
         


### PR DESCRIPTION
Disabled interactions with the depth view until it has completed its presentation animation to prevent issues where it was being dismissed right as it was being show with a well timed double tap.
